### PR TITLE
Show group name on the index page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,7 +14,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(:name,user_ids:[])
   end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,5 +2,4 @@ class Group < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   has_many :members
   has_many :users,through: :members
-  accepts_nested_attributes_for :members
 end

--- a/app/views/messages/_group.html.haml
+++ b/app/views/messages/_group.html.haml
@@ -8,7 +8,10 @@
       = current_user.name
   %div.group__bottom
     %a{href: "localhot:3000/",style: "text-decoration: none"}
-      %div.bottom__chank
-        %ul.group
-          %li.group_name test
-          %li.message  まだメッセージはありません
+    -if user_signed_in?
+      -current_user.groups.each do |g|
+        %div.bottom__chank
+          %ul.group
+            %li.group_name
+            = g.name
+            %li.message  まだメッセージはありません


### PR DESCRIPTION
# WHAT
中間テーブルとuser groupを連携・ index画面にユーザーのgroupを表示

# WHY
userとgroupを結びつけるため

![2017-07-06 16 23 14](https://user-images.githubusercontent.com/29746381/27900152-21f28a30-6268-11e7-9fa3-017d3e983983.png)
![2017-07-06 16 23 30](https://user-images.githubusercontent.com/29746381/27900154-21f7a7c2-6268-11e7-9ac9-deb4c244b098.png)
![2017-07-06 16 24 34](https://user-images.githubusercontent.com/29746381/27900153-21f65c1e-6268-11e7-816b-371504f1648c.png)