### PR TITLE
Fix group form

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,8 +53,6 @@ $(document).on('turbolinks:load',function(){
         dataType: 'json'
       })
       .always(function(data){
-        console.log(message_id)
-        console.log(data)
         $.each(data, function(i,data){
           var html = buildHTML(data);
           $('.chats').append(html);

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -26,7 +26,7 @@ $(document).on('turbolinks:load',function(){
   $.ajax({
     url: '/users/search',
     type: 'GET',
-    data: (input),
+    data: ("keyword=" + input),
     processData: false,
     contentType: false,
     dataType: 'json'
@@ -53,3 +53,4 @@ $(document).on('turbolinks:load',function(){
     });
   });
 });
+

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,6 +6,7 @@ class GroupsController < ApplicationController
 
   def new
     @group = Group.new
+    @user = current_user
   end
 
 

--- a/app/views/groups/_chat-member.html.haml
+++ b/app/views/groups/_chat-member.html.haml
@@ -1,0 +1,11 @@
+-@group.users.each do |user|
+  .chat-group-user.clearfix.js-chat-member{:id => "chat-group-user-#{user.id}", :user_id => "#{user.id}", :user_name => "#{user.name}"}
+    %input{:name => "group[user_ids][]", :type => "hidden", :value => "#{user.id}"}
+    %p.chat-group-user__name
+      =user.name
+    %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+-if @user.present?
+  .chat-group-user.clearfix.js-chat-member{:id => "chat-group-user-#{current_user.id}", :user_id => "#{current_user.id}", :user_name => "#{current_user.name}"}
+    %input{:name => "group[user_ids][]", :type => "hidden", :value => "#{current_user.id}"}
+    %p.chat-group-user__name
+      =current_user.name

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -23,6 +23,7 @@
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         #users_wrap
+          =render 'chat-member'
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right


### PR DESCRIPTION
# WHAT
Group作成/編集機能を修正(既存メンバーをチャットメンバー欄に追記)

# WHY
ユーザーが現在の既存のメンバーを把握できるようにするため

